### PR TITLE
Adjust type of BillingRequest.before and BillingRequest.after

### DIFF
--- a/src/weni/protobuf/flows/billing.proto
+++ b/src/weni/protobuf/flows/billing.proto
@@ -12,8 +12,8 @@ service Billing {
 
 message BillingRequest {
     string org_uuid = 1;
-    google.protobuf.Timestamp before = 2;
-    google.protobuf.Timestamp after = 3;
+    string before = 2;
+    string after = 3;
 }
 
 message BillingResponse {


### PR DESCRIPTION
Change type of `BillingRequest.before` and `BillingRequest.after` from `Timestamp` to `string`