### PR TITLE
Return UUID on Weni Web Chat Channel endpoint

### DIFF
--- a/python/weni/protobuf/flows/channel_pb2.py
+++ b/python/weni/protobuf/flows/channel_pb2.py
@@ -19,7 +19,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   syntax='proto3',
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n!weni/protobuf/flows/channel.proto\x12\x12weni.flows.channel\"H\n\x18WeniWebChatCreateRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04user\x18\x02 \x01(\t\x12\x10\n\x08\x62\x61se_url\x18\x03 \x01(\t\"\x1b\n\x0bWeniWebChat\x12\x0c\n\x04name\x18\x01 \x01(\t2r\n\x15WeniWebChatController\x12Y\n\x06\x43reate\x12,.weni.flows.channel.WeniWebChatCreateRequest\x1a\x1f.weni.flows.channel.WeniWebChat\"\x00\x62\x06proto3'
+  serialized_pb=b'\n!weni/protobuf/flows/channel.proto\x12\x12weni.flows.channel\"H\n\x18WeniWebChatCreateRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04user\x18\x02 \x01(\t\x12\x10\n\x08\x62\x61se_url\x18\x03 \x01(\t\"\x1b\n\x0bWeniWebChat\x12\x0c\n\x04uuid\x18\x01 \x01(\t2r\n\x15WeniWebChatController\x12Y\n\x06\x43reate\x12,.weni.flows.channel.WeniWebChatCreateRequest\x1a\x1f.weni.flows.channel.WeniWebChat\"\x00\x62\x06proto3'
 )
 
 
@@ -80,7 +80,7 @@ _WENIWEBCHAT = _descriptor.Descriptor(
   create_key=_descriptor._internal_create_key,
   fields=[
     _descriptor.FieldDescriptor(
-      name='name', full_name='weni.flows.channel.WeniWebChat.name', index=0,
+      name='uuid', full_name='weni.flows.channel.WeniWebChat.uuid', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=b"".decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,

--- a/src/weni/protobuf/flows/channel.proto
+++ b/src/weni/protobuf/flows/channel.proto
@@ -13,6 +13,6 @@ message WeniWebChatCreateRequest {
 }
 
 message WeniWebChat {
-    string name = 1;
+    string uuid = 1;
 }
 


### PR DESCRIPTION
The endpoint was returning `name` instead of channel UUID, this PR aims to solve it.