### PR TITLE
Bump to 1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [1.2.2] - 2021-11-11
+### Added
+- Generic endpoint to create channels by channeltype_code
+
 ## [1.2.1] - 2021-10-28
 ### Added
 - channel release endpoint (#42)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "weni-protobuffers"
-version = "1.2.1"
+version = "1.2.2"
 description = "Protocol Buffers for Weni Platform"
 authors = ["João Carlos <jcbalmeida@gmail.com>"]
 packages = [


### PR DESCRIPTION
Main changes:
- Add [last PR](https://github.com/Ilhasoft/weni-protobuffers/pull/44) to `CHANGELOG.md`
- Bump weni-protobuffers from  1.2.1 to 1.2.2