### PR TITLE
Bump to 1.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+## [1.2.4] - 2021-12-01
+### Added
+- Add Retrieve and List endpoints to Channel service
+- Added new fields to channel generic endpoint
+
 ## [1.2.3] - 2021-11-16
 ### Added
 - Generic endpoint to create channels on connect

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "weni-protobuffers"
-version = "1.2.3"
+version = "1.2.4"
 description = "Protocol Buffers for Weni Platform"
 authors = ["João Carlos <jcbalmeida@gmail.com>"]
 packages = [


### PR DESCRIPTION
Main changes:
- Add last PRs to CHANGELOG.md
- Bump weni-protobuffers from 1.2.3 to 1.2.4
