### PR TITLE
Bump to 1.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [1.2.5] - 2021-12-07
+### Added
+- name, config, and address fields to CreateChannelResponse on connect
+
 ## [1.2.4] - 2021-12-01
 ### Added
 - Add Retrieve and List endpoints to Channel service

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "weni-protobuffers"
-version = "1.2.4"
+version = "1.2.5"
 description = "Protocol Buffers for Weni Platform"
 authors = ["João Carlos <jcbalmeida@gmail.com>"]
 packages = [


### PR DESCRIPTION
Main changes:
- Add last PR to CHANGELOG.md
- Bump weni-protobuffers from 1.2.4 to 1.2.5