### PR TITLE
Bump to 1.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [1.2.7] - 2021-12-17
+### Added
+- Whatsapp router channel.proto
+
 ## [1.2.6] - 2021-12-13
 ### Added
 - Add retrieve organization endpoint (#53)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "weni-protobuffers"
-version = "1.2.6"
+version = "1.2.7"
 description = "Protocol Buffers for Weni Platform"
 authors = ["João Carlos <jcbalmeida@gmail.com>"]
 packages = [


### PR DESCRIPTION
Main changes:

- Add the last PR to CHANGELOG.md;
- Bump weni-protobuffers from 1.2.6 to 1.2.7