### PR TITLE
Refactor some billing endpoint nomenclatures

### DIFF
--- a/python/weni/protobuf/flows/billing_pb2.py
+++ b/python/weni/protobuf/flows/billing_pb2.py
@@ -21,7 +21,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   syntax='proto3',
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n!weni/protobuf/flows/billing.proto\x12\x12weni.flows.billing\x1a\x1fgoogle/protobuf/timestamp.proto\"A\n\x0e\x42illingRequest\x12\x10\n\x08org_uuid\x18\x01 \x01(\t\x12\x0e\n\x06\x62\x65\x66ore\x18\x02 \x01(\t\x12\r\n\x05\x61\x66ter\x18\x03 \x01(\t\"*\n\x0f\x42illingResponse\x12\x17\n\x0f\x61\x63tive_contacts\x18\x01 \x01(\x05\"\x80\x01\n\x03Msg\x12\x0c\n\x04uuid\x18\x01 \x01(\t\x12\x0c\n\x04text\x18\x02 \x01(\t\x12+\n\x07sent_on\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x30\n\tdirection\x18\x04 \x01(\x0e\x32\x1d.weni.flows.billing.Direction\"%\n\x07\x43hannel\x12\x0c\n\x04uuid\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\"\x85\x01\n\x13\x41\x63tiveContactDetail\x12\x0c\n\x04uuid\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12$\n\x03msg\x18\x03 \x01(\x0b\x32\x17.weni.flows.billing.Msg\x12,\n\x07\x63hannel\x18\x04 \x01(\x0b\x32\x1b.weni.flows.billing.Channel*\"\n\tDirection\x12\t\n\x05INPUT\x10\x00\x12\n\n\x06OUTPUT\x10\x01\x32\xba\x01\n\x07\x42illing\x12R\n\x05Total\x12\".weni.flows.billing.BillingRequest\x1a#.weni.flows.billing.BillingResponse\"\x00\x12[\n\x08\x44\x65tailed\x12\".weni.flows.billing.BillingRequest\x1a\'.weni.flows.billing.ActiveContactDetail\"\x00\x30\x01\x62\x06proto3'
+  serialized_pb=b'\n!weni/protobuf/flows/billing.proto\x12\x12weni.flows.billing\x1a\x1fgoogle/protobuf/timestamp.proto\"<\n\x0e\x42illingRequest\x12\x0b\n\x03org\x18\x01 \x01(\t\x12\x0e\n\x06\x62\x65\x66ore\x18\x02 \x01(\t\x12\r\n\x05\x61\x66ter\x18\x03 \x01(\t\"(\n\rTotalResponse\x12\x17\n\x0f\x61\x63tive_contacts\x18\x01 \x01(\x05\"\x80\x01\n\x03Msg\x12\x0c\n\x04uuid\x18\x01 \x01(\t\x12\x0c\n\x04text\x18\x02 \x01(\t\x12+\n\x07sent_on\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x30\n\tdirection\x18\x04 \x01(\x0e\x32\x1d.weni.flows.billing.Direction\"%\n\x07\x43hannel\x12\x0c\n\x04uuid\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\"\x85\x01\n\x13\x41\x63tiveContactDetail\x12\x0c\n\x04uuid\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12$\n\x03msg\x18\x03 \x01(\x0b\x32\x17.weni.flows.billing.Msg\x12,\n\x07\x63hannel\x18\x04 \x01(\x0b\x32\x1b.weni.flows.billing.Channel*\"\n\tDirection\x12\t\n\x05INPUT\x10\x00\x12\n\n\x06OUTPUT\x10\x01\x32\xc2\x01\n\x11\x42illingController\x12P\n\x05Total\x12\".weni.flows.billing.BillingRequest\x1a!.weni.flows.billing.TotalResponse\"\x00\x12[\n\x08\x44\x65tailed\x12\".weni.flows.billing.BillingRequest\x1a\'.weni.flows.billing.ActiveContactDetail\"\x00\x30\x01\x62\x06proto3'
   ,
   dependencies=[google_dot_protobuf_dot_timestamp__pb2.DESCRIPTOR,])
 
@@ -45,8 +45,8 @@ _DIRECTION = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=507,
-  serialized_end=541,
+  serialized_start=500,
+  serialized_end=534,
 )
 _sym_db.RegisterEnumDescriptor(_DIRECTION)
 
@@ -65,7 +65,7 @@ _BILLINGREQUEST = _descriptor.Descriptor(
   create_key=_descriptor._internal_create_key,
   fields=[
     _descriptor.FieldDescriptor(
-      name='org_uuid', full_name='weni.flows.billing.BillingRequest.org_uuid', index=0,
+      name='org', full_name='weni.flows.billing.BillingRequest.org', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=b"".decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -98,20 +98,20 @@ _BILLINGREQUEST = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=90,
-  serialized_end=155,
+  serialized_end=150,
 )
 
 
-_BILLINGRESPONSE = _descriptor.Descriptor(
-  name='BillingResponse',
-  full_name='weni.flows.billing.BillingResponse',
+_TOTALRESPONSE = _descriptor.Descriptor(
+  name='TotalResponse',
+  full_name='weni.flows.billing.TotalResponse',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   create_key=_descriptor._internal_create_key,
   fields=[
     _descriptor.FieldDescriptor(
-      name='active_contacts', full_name='weni.flows.billing.BillingResponse.active_contacts', index=0,
+      name='active_contacts', full_name='weni.flows.billing.TotalResponse.active_contacts', index=0,
       number=1, type=5, cpp_type=1, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
@@ -129,8 +129,8 @@ _BILLINGRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=157,
-  serialized_end=199,
+  serialized_start=152,
+  serialized_end=192,
 )
 
 
@@ -182,8 +182,8 @@ _MSG = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=202,
-  serialized_end=330,
+  serialized_start=195,
+  serialized_end=323,
 )
 
 
@@ -221,8 +221,8 @@ _CHANNEL = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=332,
-  serialized_end=369,
+  serialized_start=325,
+  serialized_end=362,
 )
 
 
@@ -274,8 +274,8 @@ _ACTIVECONTACTDETAIL = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=372,
-  serialized_end=505,
+  serialized_start=365,
+  serialized_end=498,
 )
 
 _MSG.fields_by_name['sent_on'].message_type = google_dot_protobuf_dot_timestamp__pb2._TIMESTAMP
@@ -283,7 +283,7 @@ _MSG.fields_by_name['direction'].enum_type = _DIRECTION
 _ACTIVECONTACTDETAIL.fields_by_name['msg'].message_type = _MSG
 _ACTIVECONTACTDETAIL.fields_by_name['channel'].message_type = _CHANNEL
 DESCRIPTOR.message_types_by_name['BillingRequest'] = _BILLINGREQUEST
-DESCRIPTOR.message_types_by_name['BillingResponse'] = _BILLINGRESPONSE
+DESCRIPTOR.message_types_by_name['TotalResponse'] = _TOTALRESPONSE
 DESCRIPTOR.message_types_by_name['Msg'] = _MSG
 DESCRIPTOR.message_types_by_name['Channel'] = _CHANNEL
 DESCRIPTOR.message_types_by_name['ActiveContactDetail'] = _ACTIVECONTACTDETAIL
@@ -297,12 +297,12 @@ BillingRequest = _reflection.GeneratedProtocolMessageType('BillingRequest', (_me
   })
 _sym_db.RegisterMessage(BillingRequest)
 
-BillingResponse = _reflection.GeneratedProtocolMessageType('BillingResponse', (_message.Message,), {
-  'DESCRIPTOR' : _BILLINGRESPONSE,
+TotalResponse = _reflection.GeneratedProtocolMessageType('TotalResponse', (_message.Message,), {
+  'DESCRIPTOR' : _TOTALRESPONSE,
   '__module__' : 'weni.protobuf.flows.billing_pb2'
-  # @@protoc_insertion_point(class_scope:weni.flows.billing.BillingResponse)
+  # @@protoc_insertion_point(class_scope:weni.flows.billing.TotalResponse)
   })
-_sym_db.RegisterMessage(BillingResponse)
+_sym_db.RegisterMessage(TotalResponse)
 
 Msg = _reflection.GeneratedProtocolMessageType('Msg', (_message.Message,), {
   'DESCRIPTOR' : _MSG,
@@ -327,29 +327,29 @@ _sym_db.RegisterMessage(ActiveContactDetail)
 
 
 
-_BILLING = _descriptor.ServiceDescriptor(
-  name='Billing',
-  full_name='weni.flows.billing.Billing',
+_BILLINGCONTROLLER = _descriptor.ServiceDescriptor(
+  name='BillingController',
+  full_name='weni.flows.billing.BillingController',
   file=DESCRIPTOR,
   index=0,
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_start=544,
-  serialized_end=730,
+  serialized_start=537,
+  serialized_end=731,
   methods=[
   _descriptor.MethodDescriptor(
     name='Total',
-    full_name='weni.flows.billing.Billing.Total',
+    full_name='weni.flows.billing.BillingController.Total',
     index=0,
     containing_service=None,
     input_type=_BILLINGREQUEST,
-    output_type=_BILLINGRESPONSE,
+    output_type=_TOTALRESPONSE,
     serialized_options=None,
     create_key=_descriptor._internal_create_key,
   ),
   _descriptor.MethodDescriptor(
     name='Detailed',
-    full_name='weni.flows.billing.Billing.Detailed',
+    full_name='weni.flows.billing.BillingController.Detailed',
     index=1,
     containing_service=None,
     input_type=_BILLINGREQUEST,
@@ -358,8 +358,8 @@ _BILLING = _descriptor.ServiceDescriptor(
     create_key=_descriptor._internal_create_key,
   ),
 ])
-_sym_db.RegisterServiceDescriptor(_BILLING)
+_sym_db.RegisterServiceDescriptor(_BILLINGCONTROLLER)
 
-DESCRIPTOR.services_by_name['Billing'] = _BILLING
+DESCRIPTOR.services_by_name['BillingController'] = _BILLINGCONTROLLER
 
 # @@protoc_insertion_point(module_scope)

--- a/python/weni/protobuf/flows/billing_pb2_grpc.py
+++ b/python/weni/protobuf/flows/billing_pb2_grpc.py
@@ -5,7 +5,7 @@ import grpc
 from weni.protobuf.flows import billing_pb2 as weni_dot_protobuf_dot_flows_dot_billing__pb2
 
 
-class BillingStub(object):
+class BillingControllerStub(object):
     """Missing associated documentation comment in .proto file."""
 
     def __init__(self, channel):
@@ -15,18 +15,18 @@ class BillingStub(object):
             channel: A grpc.Channel.
         """
         self.Total = channel.unary_unary(
-                '/weni.flows.billing.Billing/Total',
+                '/weni.flows.billing.BillingController/Total',
                 request_serializer=weni_dot_protobuf_dot_flows_dot_billing__pb2.BillingRequest.SerializeToString,
-                response_deserializer=weni_dot_protobuf_dot_flows_dot_billing__pb2.BillingResponse.FromString,
+                response_deserializer=weni_dot_protobuf_dot_flows_dot_billing__pb2.TotalResponse.FromString,
                 )
         self.Detailed = channel.unary_stream(
-                '/weni.flows.billing.Billing/Detailed',
+                '/weni.flows.billing.BillingController/Detailed',
                 request_serializer=weni_dot_protobuf_dot_flows_dot_billing__pb2.BillingRequest.SerializeToString,
                 response_deserializer=weni_dot_protobuf_dot_flows_dot_billing__pb2.ActiveContactDetail.FromString,
                 )
 
 
-class BillingServicer(object):
+class BillingControllerServicer(object):
     """Missing associated documentation comment in .proto file."""
 
     def Total(self, request, context):
@@ -43,12 +43,12 @@ class BillingServicer(object):
         raise NotImplementedError('Method not implemented!')
 
 
-def add_BillingServicer_to_server(servicer, server):
+def add_BillingControllerServicer_to_server(servicer, server):
     rpc_method_handlers = {
             'Total': grpc.unary_unary_rpc_method_handler(
                     servicer.Total,
                     request_deserializer=weni_dot_protobuf_dot_flows_dot_billing__pb2.BillingRequest.FromString,
-                    response_serializer=weni_dot_protobuf_dot_flows_dot_billing__pb2.BillingResponse.SerializeToString,
+                    response_serializer=weni_dot_protobuf_dot_flows_dot_billing__pb2.TotalResponse.SerializeToString,
             ),
             'Detailed': grpc.unary_stream_rpc_method_handler(
                     servicer.Detailed,
@@ -57,12 +57,12 @@ def add_BillingServicer_to_server(servicer, server):
             ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
-            'weni.flows.billing.Billing', rpc_method_handlers)
+            'weni.flows.billing.BillingController', rpc_method_handlers)
     server.add_generic_rpc_handlers((generic_handler,))
 
 
  # This class is part of an EXPERIMENTAL API.
-class Billing(object):
+class BillingController(object):
     """Missing associated documentation comment in .proto file."""
 
     @staticmethod
@@ -76,9 +76,9 @@ class Billing(object):
             wait_for_ready=None,
             timeout=None,
             metadata=None):
-        return grpc.experimental.unary_unary(request, target, '/weni.flows.billing.Billing/Total',
+        return grpc.experimental.unary_unary(request, target, '/weni.flows.billing.BillingController/Total',
             weni_dot_protobuf_dot_flows_dot_billing__pb2.BillingRequest.SerializeToString,
-            weni_dot_protobuf_dot_flows_dot_billing__pb2.BillingResponse.FromString,
+            weni_dot_protobuf_dot_flows_dot_billing__pb2.TotalResponse.FromString,
             options, channel_credentials,
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
@@ -93,7 +93,7 @@ class Billing(object):
             wait_for_ready=None,
             timeout=None,
             metadata=None):
-        return grpc.experimental.unary_stream(request, target, '/weni.flows.billing.Billing/Detailed',
+        return grpc.experimental.unary_stream(request, target, '/weni.flows.billing.BillingController/Detailed',
             weni_dot_protobuf_dot_flows_dot_billing__pb2.BillingRequest.SerializeToString,
             weni_dot_protobuf_dot_flows_dot_billing__pb2.ActiveContactDetail.FromString,
             options, channel_credentials,

--- a/src/weni/protobuf/flows/billing.proto
+++ b/src/weni/protobuf/flows/billing.proto
@@ -4,19 +4,19 @@ package weni.flows.billing;
 
 import "google/protobuf/timestamp.proto";
 
-service Billing {
+service BillingController {
     // Get the total or active contacts in a time range
-    rpc Total(BillingRequest) returns (BillingResponse){}
+    rpc Total(BillingRequest) returns (TotalResponse){}
     rpc Detailed(BillingRequest) returns (stream ActiveContactDetail){}
 }
 
 message BillingRequest {
-    string org_uuid = 1;
+    string org = 1;
     string before = 2;
     string after = 3;
 }
 
-message BillingResponse {
+message TotalResponse {
     int32 active_contacts = 1;
 }
 
@@ -31,6 +31,7 @@ message Msg {
     google.protobuf.Timestamp sent_on = 3;
     Direction direction = 4;
 }
+
 message Channel {
     string uuid = 1;
     string name = 2;


### PR DESCRIPTION
The purpose of this PR is to adjust the billing endpoint to the `weni-protobuffers` standards

Main changes:
- Rename service from `Billing` to `BillingController`
- Rename BillingRequest.org_uuid to BillingRequest.org
- Rename message from `BillingResponse` to `TotalResponse`
